### PR TITLE
Fix YAML loading for newer Ruby versions

### DIFF
--- a/lib/rubyfocus/document.rb
+++ b/lib/rubyfocus/document.rb
@@ -61,7 +61,7 @@ class Rubyfocus::Document
 
 	# Load from a a hash
 	def self.load_from_file(file_location)
-		d = YAML::load_file(file_location)
+		d = YAML::unsafe_load_file(file_location)
 		d.fetcher.reset
 		d
 	end


### PR DESCRIPTION
Closes #8

I think it's fine to use `unsafe_load_file` here since the data is presumably coming from the user's own OmniFocus, so is unlikely to contain anything malicious.