### PR TITLE
Require gems to prevent Ruby warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,9 @@ PATH
   remote: .
   specs:
     rubyfocus (0.6.0)
+      base64
+      bigdecimal
+      csv
       httparty (~> 0.13, >= 0.13.7)
       nokogiri (~> 1.8, >= 1.8.5)
       rubyzip (~> 1.2, >= 1.2.2)
@@ -9,6 +12,9 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    base64 (0.2.0)
+    bigdecimal (3.1.6)
+    csv (3.2.8)
     diff-lcs (1.5.0)
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
@@ -35,7 +41,6 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
-  ruby
 
 DEPENDENCIES
   rspec

--- a/rubyfocus.gemspec
+++ b/rubyfocus.gemspec
@@ -4,14 +4,14 @@ Gem::Specification.new do |s|
   s.name = "rubyfocus"
   s.version = File.read("version.txt")
   s.licenses = ["MIT"]
-  
+
   s.summary = "Pure ruby bridge to OmniFocus."
   s.description = "Use this gem to talk to OmniFocus. Extracts projects, contexts, and tasks from local or remote OmniFocus databases."
-  
+
   s.author = "Jan-Yves Ruzicka"
   s.email = "jan@1klb.com"
   s.homepage = "https://github.com/jyruzicka/rubyfocus"
-  
+
   s.files = File.read("Manifest").split("\n").select{ |l| !l.start_with?("#") && l != ""}
   s.require_paths << "lib"
   s.extra_rdoc_files = ["README.md"]
@@ -20,4 +20,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "nokogiri", "~> 1.8", ">= 1.8.5"
   s.add_runtime_dependency "rubyzip", "~> 1.2", ">= 1.2.2"
   s.add_runtime_dependency "httparty", "~> 0.13", ">= 0.13.7"
+  s.add_runtime_dependency "base64"
+  s.add_runtime_dependency "bigdecimal"
+  s.add_runtime_dependency "csv"
 end


### PR DESCRIPTION
Prevents the below warnings, and ensures it will keep working once Ruby 3.4 is released.

```
/Users/andy/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/multi_xml-0.6.0/lib/multi_xml.rb:1: warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec. Also contact author of multi_xml-0.6.0 to add base64 into its gemspec.
/Users/andy/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/multi_xml-0.6.0/lib/multi_xml.rb:2: warning: bigdecimal was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add bigdecimal to your Gemfile or gemspec. Also contact author of multi_xml-0.6.0 to add bigdecimal into its gemspec.
/Users/andy/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/httparty-0.21.0/lib/httparty.rb:10: warning: csv was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec. Also contact author of httparty-0.21.0 to add csv into its gemspec.
```